### PR TITLE
Do not map method overrides for interface method definitions

### DIFF
--- a/Mono.Reflection/AssemblySaver.cs
+++ b/Mono.Reflection/AssemblySaver.cs
@@ -157,7 +157,7 @@ namespace Mono.Reflection {
 				return;
 
 			var type = method.DeclaringType;
-			if (type == null)
+			if (type == null || type.IsInterface)
 				return;
 
 			var overrides = type


### PR DESCRIPTION
Fixes a crash that commonly occurs when assembly defines interfaces that inherit other interfaces.