### PR TITLE
Fix Instruction.Size throwing InvalidCastException

### DIFF
--- a/Mono.Reflection/Instruction.cs
+++ b/Mono.Reflection/Instruction.cs
@@ -70,7 +70,7 @@ namespace Mono.Reflection {
 
 				switch (opcode.OperandType) {
 				case OperandType.InlineSwitch:
-					size += (1 + ((int []) operand).Length) * 4;
+					size += (1 + ((Instruction []) operand).Length) * 4;
 					break;
 				case OperandType.InlineI8:
 				case OperandType.InlineR:


### PR DESCRIPTION
When Instruction has InlineSwitch operand type then Size property throws InvalidCastException